### PR TITLE
feat(deps): upgrade dependencies

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,9 +7,11 @@ indent_size = 2
 indent_style = space
 insert_final_newline = true
 trim_trailing_whitespace = true
+max_line_length = 100
 
 [*.java]
 ij_java_use_single_class_imports = true
+max_line_length = 120
 
 [*.{kt,kts}]
 ij_kotlin_imports_layout = *
@@ -20,8 +22,9 @@ ktlint_standard_property-naming = disabled
 ktlint_standard_backing-property-naming = disabled
 ktlint_function_naming_ignore_when_annotated_with = Composable, Test
 
-[*.md]
+[*.{md,mdx,diff}]
 trim_trailing_whitespace = false
 
 [Makefile]
+indent_size = 4
 indent_style = tab

--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="KotlinJpsPluginSettings">
-    <option name="version" value="2.0.20" />
+    <option name="version" value="2.0.21" />
   </component>
 </project>

--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -10,6 +10,9 @@ repositories {
   mavenCentral()
   gradlePluginPortal()
   google()
+  maven("https://maven.aliyun.com/repository/public")
+  maven("https://maven.aliyun.com/repository/gradle-plugin")
+  maven("https://maven.aliyun.com/repository/google")
 }
 
 group = "com.jithub.app.build-logic"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,6 +11,9 @@ buildscript {
       }
     }
     gradlePluginPortal()
+    maven("https://maven.aliyun.com/repository/public")
+    maven("https://maven.aliyun.com/repository/google")
+    maven("https://maven.aliyun.com/repository/gradle-plugin")
   }
   dependencies {
     classpath(libs.redwood.gradle.plugin)
@@ -38,6 +41,8 @@ allprojects {
         includeGroupAndSubgroups("com.google")
       }
     }
+    maven("https://maven.aliyun.com/repository/public")
+    maven("https://maven.aliyun.com/repository/google")
     maven("https://jitpack.io")
   }
   apply(plugin = "com.jithub.gradle.build-support")

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
-kotlin = "2.0.20"
+kotlin = "2.0.21"
 agp = "8.2.2"
-redwood = "0.14.0"
+redwood = "0.15.0"
 
 androidx-activityCompose = "1.9.1"
 androidx-appcompat = "1.7.0"
@@ -9,7 +9,7 @@ androidx-constraintlayout = "2.1.4"
 androidx-core-ktx = "1.13.1"
 androidx-material = "1.12.0"
 
-jbr-compose = "1.6.11"
+jbr-compose = "1.7.0"
 
 androidx-espresso-core = "3.6.1"
 androidx-test-junit = "1.2.1"

--- a/gradle/moko.versions.toml
+++ b/gradle/moko.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 # https://repo.maven.apache.org/maven2/dev/icerock/moko/resources/
-resources = "0.24.2"
+resources = "0.24.3"
 
 [plugins]
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip
+distributionUrl=https\://mirrors.aliyun.com/macports/distfiles/gradle/gradle-8.8-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/redwood/schema/src/main/kotlin/com/jithub/app/shared/redwood/schema.kt
+++ b/redwood/schema/src/main/kotlin/com/jithub/app/shared/redwood/schema.kt
@@ -3,7 +3,6 @@
 package com.jithub.app.shared.redwood
 
 import app.cash.redwood.layout.RedwoodLayout
-import app.cash.redwood.schema.Default
 import app.cash.redwood.schema.Property
 import app.cash.redwood.schema.Schema
 import app.cash.redwood.schema.Schema.Dependency
@@ -27,7 +26,6 @@ data class Text(@Property(1) val text: String?)
 data class Button(
   @Property(1) val text: String?,
   @Property(2)
-  @Default("true")
   val enabled: Boolean = true,
   @Property(3) val onClick: (() -> Unit)? = null,
 )

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -14,6 +14,9 @@ pluginManagement {
       }
     }
     gradlePluginPortal()
+    maven("https://maven.aliyun.com/repository/public")
+    maven("https://maven.aliyun.com/repository/google")
+    maven("https://maven.aliyun.com/repository/gradle-plugin")
   }
 }
 

--- a/shared/src/commonMain/kotlin/com/jithub/app/shared/Counter.kt
+++ b/shared/src/commonMain/kotlin/com/jithub/app/shared/Counter.kt
@@ -15,7 +15,11 @@ import com.jithub.app.shared.redwood.compose.Button
 import com.jithub.app.shared.redwood.compose.Text
 
 @Composable
-fun Counter(modifier: Modifier = Modifier, value: Int = 0, labels: StringList? = StringList(listOf())) {
+fun Counter(
+  modifier: Modifier = Modifier,
+  value: Int = 0,
+  labels: StringList? = StringList(listOf()),
+) {
   var count by rememberSaveable { mutableIntStateOf(value) }
   Column(
     width = Constraint.Fill,


### PR DESCRIPTION
Upgrades the following dependencies:
- `moko-resources` from `0.24.2` to `0.24.3`
- `jbr-compose` from `1.6.11` to `1.7.0`
- `kotlin` from `2.0.20` to `2.0.21`
- `redwood` from `0.14.0` to `0.15.0`